### PR TITLE
Add join argument to `check_data_format` to separate join checks from complete checks

### DIFF
--- a/R/check-data-format.R
+++ b/R/check-data-format.R
@@ -47,6 +47,7 @@ check_data_format <- function(..., template, complete = FALSE, join = FALSE) {
   chk::chk_used(...)
   chk::chk_list(template)
   chk::chk_lgl(complete)
+  chk::chk_lgl(join)
 
   data <- list(...)
   template_names <- names(template)

--- a/R/check-data-format.R
+++ b/R/check-data-format.R
@@ -46,8 +46,8 @@
 check_data_format <- function(..., template, complete = FALSE, join = FALSE) {
   chk::chk_used(...)
   chk::chk_list(template)
-  chk::chk_lgl(complete)
-  chk::chk_lgl(join)
+  chk::chk_flag(complete)
+  chk::chk_flag(join)
 
   data <- list(...)
   template_names <- names(template)

--- a/R/check-data-format.R
+++ b/R/check-data-format.R
@@ -8,16 +8,18 @@
 #' @param template A list of named data frames that make up the template
 #' @param complete A logical indicating if all tables present in the template
 #'   need to be supplied in the ... argument. If TRUE all tables need to be
-#'   provided in ... argument, default is set to FALSE. This must be set to TRUE
-#'   to check joins between the tables.
+#'   provided in ... argument, default is set to FALSE.
+#' @param join A logical indicating if joins between the tables should be
+#'   checked. If TRUE joins are checked, default is set to FALSE.
 #'
 #' @details The template argument should contain all the sheets in the template
 #' while the ... argument can be which ever set of data tables you want to check
 #' against the template. This means either one, several or all the data tables
 #' can be checked against the template.
 #'
-#' If complete is set to TRUE then all the data tables need to be supplied and
-#' the function can check joins between the tables.
+#' If complete is set to TRUE then all the data tables need to be supplied.
+#' If join is set to TRUE then the joins between the provided tables are
+#' checked.
 #'
 #' @return A list of named data frames of the data
 #' @export
@@ -27,19 +29,21 @@
 #' check_data_format(
 #'   outing = outing,
 #'   template = demo_template_fish_exploit,
-#'   complete = FALSE
+#'   complete = FALSE,
+#'   join = FALSE
 #' )
 #'
 #' check_data_format(
-#'   site = site
+#'   site = site,
 #'   outing = outing,
 #'   capture = capture,
 #'   recapture = recapture,
 #'   template = demo_template_fish_exploit,
-#'   complete = TRUE
+#'   complete = TRUE,
+#'   join = TRUE
 #' )
 #' }
-check_data_format <- function(..., template, complete = FALSE) {
+check_data_format <- function(..., template, complete = FALSE, join = FALSE) {
   chk::chk_used(...)
   chk::chk_list(template)
   chk::chk_lgl(complete)
@@ -63,7 +67,6 @@ check_data_format <- function(..., template, complete = FALSE) {
   data <- check_template_ranges(data, template)
 
   # if complete = TRUE then must have all names represented
-  # if complete = TRUE then check joins
   if (complete) {
     if (!all(template_names %in% data_names)) {
       chk::abort_chk(
@@ -72,9 +75,14 @@ check_data_format <- function(..., template, complete = FALSE) {
         `...` argument"
       )
     }
+  }
+  # if join = TRUE then check joins
+  if (join) {
+    template <- template[data_names]
     # check the joins
     check_template_joins(data, template)
   }
+
   data
 }
 
@@ -235,7 +243,6 @@ check_template_join <- function(data, template, sheet, join_num) {
       data[[joins[[sheet]]$tbl_x]],
       by = c(joins[[sheet]]$by)
     )) {
-
       data[[joins[[sheet]]$tbl_y]]$id <- 1:nrow(data[[joins[[sheet]]$tbl_y]])
 
       no_match <- dplyr::anti_join(

--- a/R/template-human.R
+++ b/R/template-human.R
@@ -13,7 +13,6 @@
 #' template_human(demo_template_count$visit)
 #' template_human(demo_template_fish_exploit$capture)
 template_human <- function(template) {
-  #browser()
 
   check_template(template)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -76,7 +76,7 @@ data <- check_data_format(
 )
 ```
 
-Joins are only checked if all the sheet of the template are supplied and `complete` is set to `TRUE`.
+The `complete` argument checks if all tables are present.
 
 ```{r}
 site <- data.frame(
@@ -128,6 +128,62 @@ data <- check_data_format(
   recapture = recapture,
   template = demo_template_fish_exploit,
   complete = TRUE
+)
+```
+
+Joins are only checked if `join` is set to `TRUE`.
+
+```{r}
+site <- data.frame(
+    site_name = c("Pretty Bay", "Ugly Bay", "Green Bay")
+  )
+
+outing <- data.frame(
+  outing_id = c(1L, 2L, 3L),
+  site_name = c("Pretty Bay", "Pretty Bay", "Pretty Bay"),
+  year = c(2010, 2010, 2010),
+  month = c(7, 7, 7),
+  day = c(15, 16, 17),
+  hour_start = c(9L, 11L, 8L),
+  minute_start = c(0, 0, 0),
+  guide = c("JT", "JT", "JT"),
+  rod_count = c(2, 3, 2),
+  comment = c(NA_character_, NA_character_, NA_character_)
+)
+
+capture <- data.frame(
+  outing_id = c(1L, 2L, 3L),
+  guide = c("JT", "JT", "JT"),
+  hour = c(7L, 8L, 7L),
+  minute = c(0L, 30L, 45L),
+  easting = c(1031941, 1031971, 1031944),
+  northing = c(892421, 892451, 892429),
+  species = c("BT", "CT", "CT"),
+  forklength_mm = c(100, 700, 300),
+  weight_kg = c(0.5, 10, 4),
+  tbartag_number1 = c(78, 91, 82),
+  tbartag_number2 = c(14, 18, 21),
+  released = c("yes", "no", "no")
+)
+
+recapture <- data.frame(
+  year = c(2009, 2009),
+  month = c(10, 10),
+  day = c(14, 15),
+  angler = c("Dave John", "John Smith"),
+  contact = c("250-637-9999", "250-557-1414"),
+  tbartag_number1 = c(92, 57),
+  tbartag_number2 = c(10, 12)
+)
+
+data <- check_data_format(
+  site = site,
+  outing = outing,
+  capture = capture,
+  recapture = recapture,
+  template = demo_template_fish_exploit,
+  complete = TRUE,
+  join = TRUE
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ data <- check_data_format(
 )
 ```
 
-Joins are only checked if all the sheet of the template are supplied and
-`complete` is set to `TRUE`.
+The `complete` argument checks if all tables are present.
 
 ``` r
 site <- data.frame(
@@ -143,6 +142,62 @@ data <- check_data_format(
   recapture = recapture,
   template = demo_template_fish_exploit,
   complete = TRUE
+)
+```
+
+Joins are only checked if `join` is set to `TRUE`.
+
+``` r
+site <- data.frame(
+    site_name = c("Pretty Bay", "Ugly Bay", "Green Bay")
+  )
+
+outing <- data.frame(
+  outing_id = c(1L, 2L, 3L),
+  site_name = c("Pretty Bay", "Pretty Bay", "Pretty Bay"),
+  year = c(2010, 2010, 2010),
+  month = c(7, 7, 7),
+  day = c(15, 16, 17),
+  hour_start = c(9L, 11L, 8L),
+  minute_start = c(0, 0, 0),
+  guide = c("JT", "JT", "JT"),
+  rod_count = c(2, 3, 2),
+  comment = c(NA_character_, NA_character_, NA_character_)
+)
+
+capture <- data.frame(
+  outing_id = c(1L, 2L, 3L),
+  guide = c("JT", "JT", "JT"),
+  hour = c(7L, 8L, 7L),
+  minute = c(0L, 30L, 45L),
+  easting = c(1031941, 1031971, 1031944),
+  northing = c(892421, 892451, 892429),
+  species = c("BT", "CT", "CT"),
+  forklength_mm = c(100, 700, 300),
+  weight_kg = c(0.5, 10, 4),
+  tbartag_number1 = c(78, 91, 82),
+  tbartag_number2 = c(14, 18, 21),
+  released = c("yes", "no", "no")
+)
+
+recapture <- data.frame(
+  year = c(2009, 2009),
+  month = c(10, 10),
+  day = c(14, 15),
+  angler = c("Dave John", "John Smith"),
+  contact = c("250-637-9999", "250-557-1414"),
+  tbartag_number1 = c(92, 57),
+  tbartag_number2 = c(10, 12)
+)
+
+data <- check_data_format(
+  site = site,
+  outing = outing,
+  capture = capture,
+  recapture = recapture,
+  template = demo_template_fish_exploit,
+  complete = TRUE,
+  join = TRUE
 )
 ```
 

--- a/man/check_data_format.Rd
+++ b/man/check_data_format.Rd
@@ -4,7 +4,7 @@
 \alias{check_data_format}
 \title{Check Data follow Required Format as per the Template}
 \usage{
-check_data_format(..., template, complete = FALSE)
+check_data_format(..., template, complete = FALSE, join = FALSE)
 }
 \arguments{
 \item{...}{A list of named data frames of the data}
@@ -13,8 +13,10 @@ check_data_format(..., template, complete = FALSE)
 
 \item{complete}{A logical indicating if all tables present in the template
 need to be supplied in the ... argument. If TRUE all tables need to be
-provided in ... argument, default is set to FALSE. This must be set to TRUE
-to check joins between the tables.}
+provided in ... argument, default is set to FALSE.}
+
+\item{join}{A logical indicating if joins between the tables should be
+checked. If TRUE joins are checked, default is set to FALSE.}
 }
 \value{
 A list of named data frames of the data
@@ -30,24 +32,27 @@ while the ... argument can be which ever set of data tables you want to check
 against the template. This means either one, several or all the data tables
 can be checked against the template.
 
-If complete is set to TRUE then all the data tables need to be supplied and
-the function can check joins between the tables.
+If complete is set to TRUE then all the data tables need to be supplied.
+If join is set to TRUE then the joins between the provided tables are
+checked.
 }
 \examples{
 \dontrun{
 check_data_format(
   outing = outing,
   template = demo_template_fish_exploit,
-  complete = FALSE
+  complete = FALSE,
+  join = FALSE
 )
 
 check_data_format(
-  site = site
+  site = site,
   outing = outing,
   capture = capture,
   recapture = recapture,
   template = demo_template_fish_exploit,
-  complete = TRUE
+  complete = TRUE,
+  join = TRUE
 )
 }
 }

--- a/tests/testthat/test-check-data-format.R
+++ b/tests/testthat/test-check-data-format.R
@@ -27,6 +27,130 @@ test_that("Pass when single table and all good values are passed", {
   expect_identical(data$outing$day, c(15L, 16L, 17L))
 })
 
+test_that(
+  paste(
+    "Errors when character passed to logical `complete` argument"
+  ),
+  {
+    site <- data.frame(
+      site_name = c("Pretty Bay", "Ugly Bay", "Green Bay")
+    )
+
+    outing <- data.frame(
+      outing_id = c(1L, 2L, 3L),
+      site_name = c("Pretty Bay", "Pretty Bay", "Pretty Bay"),
+      year = c(2010, 2010, 2010),
+      month = c(7, 7, 7),
+      day = c(15, 16, 17),
+      hour_start = c(9L, 11L, 8L),
+      minute_start = c(0, 0, 0),
+      guide = c("JT", "JT", "JT"),
+      rod_count = c(2, 3, 2),
+      comment = c(NA_character_, NA_character_, NA_character_)
+    )
+
+    capture <- data.frame(
+      outing_id = c(1L, 2L, 3L),
+      guide = c("JT", "JT", "JT"),
+      hour = c(7L, 8L, 7L),
+      minute = c(0L, 30L, 45L),
+      easting = c(1031941, 1031971, 1031944),
+      northing = c(892421, 892451, 892429),
+      species = c("BT", "CT", "CT"),
+      forklength_mm = c(100, 700, 300),
+      weight_kg = c(0.5, 10, 4),
+      tbartag_number1 = c(78, 91, 82),
+      tbartag_number2 = c(14, 18, 21),
+      released = c("yes", "no", "no")
+    )
+
+    recapture <- data.frame(
+      year = c(2009, 2009),
+      month = c(10, 10),
+      day = c(14, 15),
+      angler = c("Dave John", "John Smith"),
+      contact = c("250-637-9999", "250-557-1414"),
+      tbartag_number1 = c(92, 57),
+      tbartag_number2 = c(10, 12)
+    )
+
+    expect_error(
+      data <- check_data_format(
+        site = site,
+        outing = outing,
+        capture = capture,
+        recapture = recapture,
+        template = test_template_4,
+        complete = "TRUE",
+        join = TRUE
+      ),
+      regexp = "`complete` must be a logical scalar \\(TRUE, FALSE or NA\\)."
+    )
+  }
+)
+
+test_that(
+  paste(
+    "Errors when character passed to logical `join` argument"
+  ),
+  {
+    site <- data.frame(
+      site_name = c("Pretty Bay", "Ugly Bay", "Green Bay")
+    )
+
+    outing <- data.frame(
+      outing_id = c(1L, 2L, 3L),
+      site_name = c("Pretty Bay", "Pretty Bay", "Pretty Bay"),
+      year = c(2010, 2010, 2010),
+      month = c(7, 7, 7),
+      day = c(15, 16, 17),
+      hour_start = c(9L, 11L, 8L),
+      minute_start = c(0, 0, 0),
+      guide = c("JT", "JT", "JT"),
+      rod_count = c(2, 3, 2),
+      comment = c(NA_character_, NA_character_, NA_character_)
+    )
+
+    capture <- data.frame(
+      outing_id = c(1L, 2L, 3L),
+      guide = c("JT", "JT", "JT"),
+      hour = c(7L, 8L, 7L),
+      minute = c(0L, 30L, 45L),
+      easting = c(1031941, 1031971, 1031944),
+      northing = c(892421, 892451, 892429),
+      species = c("BT", "CT", "CT"),
+      forklength_mm = c(100, 700, 300),
+      weight_kg = c(0.5, 10, 4),
+      tbartag_number1 = c(78, 91, 82),
+      tbartag_number2 = c(14, 18, 21),
+      released = c("yes", "no", "no")
+    )
+
+    recapture <- data.frame(
+      year = c(2009, 2009),
+      month = c(10, 10),
+      day = c(14, 15),
+      angler = c("Dave John", "John Smith"),
+      contact = c("250-637-9999", "250-557-1414"),
+      tbartag_number1 = c(92, 57),
+      tbartag_number2 = c(10, 12)
+    )
+
+    expect_error(
+      data <- check_data_format(
+        site = site,
+        outing = outing,
+        capture = capture,
+        recapture = recapture,
+        template = test_template_4,
+        complete = TRUE,
+        join = "yes"
+      ),
+      regexp = "`join` must be a logical scalar \\(TRUE, FALSE or NA\\)."
+    )
+  }
+)
+
 test_that("Error when only 1 sheet is supplied in template of 3 sheets when
           complete is set to TRUE", {
   outing <- data.frame(

--- a/tests/testthat/test-check-data-format.R
+++ b/tests/testthat/test-check-data-format.R
@@ -241,9 +241,9 @@ test_that("No error if extra columns are supplied and extra columna present in
   )
 
   data <- check_data_format(
-      outing = outing,
-      template = test_template_4,
-      complete = FALSE
+    outing = outing,
+    template = test_template_4,
+    complete = FALSE
   )
 
   expect_type(data, "list")
@@ -376,7 +376,6 @@ test_that("Passes when 2 datasets supplied", {
     tbartag_number1 = c(78, 91, 82),
     tbartag_number2 = c(14, 18, 21),
     released = c("yes", "no", "no")
-
   )
 
   data <- check_data_format(
@@ -495,7 +494,7 @@ test_that("Passes when 3 data sheets are passed and complete is FALSE", {
   expect_identical(length(data), 3L)
 })
 
-test_that("Passes with all 4 data sheets and complete is TRUE", {
+test_that("Passes with all 4 data sheets and complete and join are TRUE", {
   site <- data.frame(
     site_name = c("Pretty Bay", "Ugly Bay", "Green Bay")
   )
@@ -544,7 +543,8 @@ test_that("Passes with all 4 data sheets and complete is TRUE", {
     capture = capture,
     recapture = recapture,
     template = test_template_4,
-    complete = TRUE
+    complete = TRUE,
+    join = TRUE
   )
 
   expect_type(data, "list")
@@ -552,17 +552,15 @@ test_that("Passes with all 4 data sheets and complete is TRUE", {
   expect_identical(length(data), 4L)
 })
 
-test_that(
-  paste(
-    "Error when all data sheets given, complete is TRUE, join values are bad",
-    "in capture table outing id"), {
+test_that("Passes with all 4 data sheets with and complete is TRUE and join
+          is FALSE, with bad joins", {
   site <- data.frame(
     site_name = c("Pretty Bay", "Ugly Bay", "Green Bay")
   )
 
   outing <- data.frame(
     outing_id = c(1L, 2L, 3L),
-    site_name = c("Pretty Bay", "Pretty Bay", "Pretty Bay"),
+    site_name = c("Pretty Bay", "Pretty Bay", "Blue Bay"),
     year = c(2010, 2010, 2010),
     month = c(7, 7, 7),
     day = c(15, 16, 17),
@@ -574,8 +572,8 @@ test_that(
   )
 
   capture <- data.frame(
-    outing_id = c(1L, 5L, 7L),
-    guide = c("JT", "JT", "JY"),
+    outing_id = c(1L, 2L, 3L),
+    guide = c("JT", "JT", "JT"),
     hour = c(7L, 8L, 7L),
     minute = c(0L, 30L, 45L),
     easting = c(1031941, 1031971, 1031944),
@@ -598,89 +596,216 @@ test_that(
     tbartag_number2 = c(10, 12)
   )
 
+  data <- check_data_format(
+    site = site,
+    outing = outing,
+    capture = capture,
+    recapture = recapture,
+    template = test_template_4,
+    complete = TRUE,
+    join = FALSE
+  )
+
+  expect_type(data, "list")
+  expect_s3_class(data$outing, "data.frame")
+  expect_identical(length(data), 4L)
+})
+
+test_that("Passes with just 2 sheets with complete FALSE and join TRUE", {
+  site <- data.frame(
+    site_name = c("Pretty Bay", "Ugly Bay", "Green Bay")
+  )
+
+  outing <- data.frame(
+    outing_id = c(1L, 2L, 3L),
+    site_name = c("Pretty Bay", "Pretty Bay", "Pretty Bay"),
+    year = c(2010, 2010, 2010),
+    month = c(7, 7, 7),
+    day = c(15, 16, 17),
+    hour_start = c(9L, 11L, 8L),
+    minute_start = c(0, 0, 0),
+    guide = c("JT", "JT", "JT"),
+    rod_count = c(2, 3, 2),
+    comment = c(NA_character_, NA_character_, NA_character_)
+  )
+
+  data <- check_data_format(
+    site = site,
+    outing = outing,
+    template = test_template_4,
+    complete = FALSE,
+    join = TRUE
+  )
+
+  expect_type(data, "list")
+  expect_s3_class(data$outing, "data.frame")
+  expect_identical(length(data), 2L)
+})
+
+test_that("Errors with complete FALSE and join TRUE, with missing join table", {
+  outing <- data.frame(
+    outing_id = c(1L, 2L, 3L),
+    site_name = c("Pretty Bay", "Pretty Bay", "Blue Bay"),
+    year = c(2010, 2010, 2010),
+    month = c(7, 7, 7),
+    day = c(15, 16, 17),
+    hour_start = c(9L, 11L, 8L),
+    minute_start = c(0, 0, 0),
+    guide = c("JT", "JT", "JT"),
+    rod_count = c(2, 3, 2),
+    comment = c(NA_character_, NA_character_, NA_character_)
+  )
+
   expect_error(
     check_data_format(
-      site = site,
       outing = outing,
-      capture = capture,
-      recapture = recapture,
       template = test_template_4,
-      complete = TRUE
+      complete = FALSE,
+      join = TRUE
     ),
     regexp = paste(
-      "All 'outing_id', 'guide' values in the capture table must be in the",
-      "outing table. The following rows\\(s\\) in the capture table are",
-      "causing the issue\\: 2, 3."
+      "The pkey values in the parent table must match the columns listed in",
+      "the child table in the join row"
     )
   )
 })
 
 test_that(
   paste(
-    "Error all data sheets given, complete is TRUE, join values are bad in",
-    "capture table guide column"
-  ), {
-  site <- data.frame(
-    site_name = c("Pretty Bay", "Ugly Bay", "Green Bay")
-  )
-
-  outing <- data.frame(
-    outing_id = c(1L, 2L, 3L),
-    site_name = c("Pretty Bay", "Pretty Bay", "Pretty Bay"),
-    year = c(2010, 2010, 2010),
-    month = c(7, 7, 7),
-    day = c(15, 16, 17),
-    hour_start = c(9L, 11L, 8L),
-    minute_start = c(0, 0, 0),
-    guide = c("JT", "JT", "JT"),
-    rod_count = c(2, 3, 2),
-    comment = c(NA_character_, NA_character_, NA_character_)
-  )
-
-  capture <- data.frame(
-    outing_id = c(1L, 2L, 3L),
-    guide = c("JT", "JT", "JY"),
-    hour = c(7L, 8L, 7L),
-    minute = c(0L, 30L, 45L),
-    easting = c(1031941, 1031971, 1031944),
-    northing = c(892421, 892451, 892429),
-    species = c("BT", "CT", "CT"),
-    forklength_mm = c(100, 700, 300),
-    weight_kg = c(0.5, 10, 4),
-    tbartag_number1 = c(78, 91, 82),
-    tbartag_number2 = c(14, 18, 21),
-    released = c("yes", "no", "no")
-  )
-
-  recapture <- data.frame(
-    year = c(2009, 2009),
-    month = c(10, 10),
-    day = c(14, 15),
-    angler = c("Dave John", "John Smith"),
-    contact = c("250-637-9999", "250-557-1414"),
-    tbartag_number1 = c(92, 57),
-    tbartag_number2 = c(10, 12)
-  )
-
-  expect_error(
-    check_data_format(
-      site = site,
-      outing = outing,
-      capture = capture,
-      recapture = recapture,
-      template = test_template_4,
-      complete = TRUE
-    ),
-    regexp = paste0(
-      "All 'outing_id', 'guide' values in the capture table must be in the ",
-      "outing table. The following rows\\(s\\) in the capture table are ",
-      "causing the issue\\: 3."
+    "Error when all data sheets given, complete and join are TRUE, join",
+    "values are bad in capture table outing id"
+  ),
+  {
+    site <- data.frame(
+      site_name = c("Pretty Bay", "Ugly Bay", "Green Bay")
     )
-  )
-})
 
-test_that("Error all data sheets given, complete is TRUE, join values are bad
-          in site table", {
+    outing <- data.frame(
+      outing_id = c(1L, 2L, 3L),
+      site_name = c("Pretty Bay", "Pretty Bay", "Pretty Bay"),
+      year = c(2010, 2010, 2010),
+      month = c(7, 7, 7),
+      day = c(15, 16, 17),
+      hour_start = c(9L, 11L, 8L),
+      minute_start = c(0, 0, 0),
+      guide = c("JT", "JT", "JT"),
+      rod_count = c(2, 3, 2),
+      comment = c(NA_character_, NA_character_, NA_character_)
+    )
+
+    capture <- data.frame(
+      outing_id = c(1L, 5L, 7L),
+      guide = c("JT", "JT", "JY"),
+      hour = c(7L, 8L, 7L),
+      minute = c(0L, 30L, 45L),
+      easting = c(1031941, 1031971, 1031944),
+      northing = c(892421, 892451, 892429),
+      species = c("BT", "CT", "CT"),
+      forklength_mm = c(100, 700, 300),
+      weight_kg = c(0.5, 10, 4),
+      tbartag_number1 = c(78, 91, 82),
+      tbartag_number2 = c(14, 18, 21),
+      released = c("yes", "no", "no")
+    )
+
+    recapture <- data.frame(
+      year = c(2009, 2009),
+      month = c(10, 10),
+      day = c(14, 15),
+      angler = c("Dave John", "John Smith"),
+      contact = c("250-637-9999", "250-557-1414"),
+      tbartag_number1 = c(92, 57),
+      tbartag_number2 = c(10, 12)
+    )
+
+    expect_error(
+      check_data_format(
+        site = site,
+        outing = outing,
+        capture = capture,
+        recapture = recapture,
+        template = test_template_4,
+        complete = TRUE,
+        join = TRUE
+      ),
+      regexp = paste(
+        "All 'outing_id', 'guide' values in the capture table must be in the",
+        "outing table. The following rows\\(s\\) in the capture table are",
+        "causing the issue\\: 2, 3."
+      )
+    )
+  }
+)
+
+test_that(
+  paste(
+    "Error all data sheets given, complete and join are TRUE, join values",
+    "are bad in capture table guide column"
+  ),
+  {
+    site <- data.frame(
+      site_name = c("Pretty Bay", "Ugly Bay", "Green Bay")
+    )
+
+    outing <- data.frame(
+      outing_id = c(1L, 2L, 3L),
+      site_name = c("Pretty Bay", "Pretty Bay", "Pretty Bay"),
+      year = c(2010, 2010, 2010),
+      month = c(7, 7, 7),
+      day = c(15, 16, 17),
+      hour_start = c(9L, 11L, 8L),
+      minute_start = c(0, 0, 0),
+      guide = c("JT", "JT", "JT"),
+      rod_count = c(2, 3, 2),
+      comment = c(NA_character_, NA_character_, NA_character_)
+    )
+
+    capture <- data.frame(
+      outing_id = c(1L, 2L, 3L),
+      guide = c("JT", "JT", "JY"),
+      hour = c(7L, 8L, 7L),
+      minute = c(0L, 30L, 45L),
+      easting = c(1031941, 1031971, 1031944),
+      northing = c(892421, 892451, 892429),
+      species = c("BT", "CT", "CT"),
+      forklength_mm = c(100, 700, 300),
+      weight_kg = c(0.5, 10, 4),
+      tbartag_number1 = c(78, 91, 82),
+      tbartag_number2 = c(14, 18, 21),
+      released = c("yes", "no", "no")
+    )
+
+    recapture <- data.frame(
+      year = c(2009, 2009),
+      month = c(10, 10),
+      day = c(14, 15),
+      angler = c("Dave John", "John Smith"),
+      contact = c("250-637-9999", "250-557-1414"),
+      tbartag_number1 = c(92, 57),
+      tbartag_number2 = c(10, 12)
+    )
+
+    expect_error(
+      check_data_format(
+        site = site,
+        outing = outing,
+        capture = capture,
+        recapture = recapture,
+        template = test_template_4,
+        complete = TRUE,
+        join = TRUE
+      ),
+      regexp = paste0(
+        "All 'outing_id', 'guide' values in the capture table must be in the ",
+        "outing table. The following rows\\(s\\) in the capture table are ",
+        "causing the issue\\: 3."
+      )
+    )
+  }
+)
+
+test_that("Error all data sheets given, complete and join are TRUE, join
+          values are bad in site table", {
   site <- data.frame(
     site_name = c("Pretty Bay", "Ugly Bay", "Green Bay")
   )
@@ -730,7 +855,8 @@ test_that("Error all data sheets given, complete is TRUE, join values are bad
       capture = capture,
       recapture = recapture,
       template = test_template_4,
-      complete = TRUE
+      complete = TRUE,
+      join = TRUE
     ),
     regexp = paste(
       "All 'site_name' values in the outing table must be in the site table.",
@@ -742,67 +868,70 @@ test_that("Error all data sheets given, complete is TRUE, join values are bad
 
 test_that(
   paste(
-    "Error all data sheets given, complete is TRUE, join values are bad in",
-    "site table"
-  ), {
-  site <- data.frame(
-    site_name = c("Pretty Bay", "Ugly Bay", "Green Bay")
-  )
-
-  outing <- data.frame(
-    outing_id = c(1L, 2L, 3L),
-    site_name = c("Pretty Bay", "Pretty bay", "Pretty Bay"),
-    year = c(2010, 2010, 2010),
-    month = c(7, 7, 7),
-    day = c(15, 16, 17),
-    hour_start = c(9L, 11L, 8L),
-    minute_start = c(0, 0, 0),
-    guide = c("JT", "JT", "JT"),
-    rod_count = c(2, 3, 2),
-    comment = c(NA_character_, NA_character_, NA_character_)
-  )
-
-  capture <- data.frame(
-    outing_id = c(1L, 5L, 7L),
-    guide = c("JT", "JT", "JT"),
-    hour = c(7L, 8L, 7L),
-    minute = c(0L, 30L, 45L),
-    easting = c(1031941, 1031971, 1031944),
-    northing = c(892421, 892451, 892429),
-    species = c("BT", "CT", "CT"),
-    forklength_mm = c(100, 700, 300),
-    weight_kg = c(0.5, 10, 4),
-    tbartag_number1 = c(78, 91, 82),
-    tbartag_number2 = c(14, 18, 21),
-    released = c("yes", "no", "no")
-  )
-
-  recapture <- data.frame(
-    year = c(2009, 2009),
-    month = c(10, 10),
-    day = c(14, 15),
-    angler = c("Dave John", "John Smith"),
-    contact = c("250-637-9999", "250-557-1414"),
-    tbartag_number1 = c(92, 57),
-    tbartag_number2 = c(10, 12)
-  )
-
-  expect_error(
-    check_data_format(
-      site = site,
-      outing = outing,
-      capture = capture,
-      recapture = recapture,
-      template = test_template_4,
-      complete = TRUE
-    ),
-    regexp = paste(
-      "All 'site_name' values in the outing table must be in the site table.",
-      "The following rows\\(s\\) in the outing table are causing the",
-      "issue\\: 2."
+    "Error all data sheets given, complete and join are TRUE, join values are",
+    "bad in site table"
+  ),
+  {
+    site <- data.frame(
+      site_name = c("Pretty Bay", "Ugly Bay", "Green Bay")
     )
-  )
-})
+
+    outing <- data.frame(
+      outing_id = c(1L, 2L, 3L),
+      site_name = c("Pretty Bay", "Pretty bay", "Pretty Bay"),
+      year = c(2010, 2010, 2010),
+      month = c(7, 7, 7),
+      day = c(15, 16, 17),
+      hour_start = c(9L, 11L, 8L),
+      minute_start = c(0, 0, 0),
+      guide = c("JT", "JT", "JT"),
+      rod_count = c(2, 3, 2),
+      comment = c(NA_character_, NA_character_, NA_character_)
+    )
+
+    capture <- data.frame(
+      outing_id = c(1L, 5L, 7L),
+      guide = c("JT", "JT", "JT"),
+      hour = c(7L, 8L, 7L),
+      minute = c(0L, 30L, 45L),
+      easting = c(1031941, 1031971, 1031944),
+      northing = c(892421, 892451, 892429),
+      species = c("BT", "CT", "CT"),
+      forklength_mm = c(100, 700, 300),
+      weight_kg = c(0.5, 10, 4),
+      tbartag_number1 = c(78, 91, 82),
+      tbartag_number2 = c(14, 18, 21),
+      released = c("yes", "no", "no")
+    )
+
+    recapture <- data.frame(
+      year = c(2009, 2009),
+      month = c(10, 10),
+      day = c(14, 15),
+      angler = c("Dave John", "John Smith"),
+      contact = c("250-637-9999", "250-557-1414"),
+      tbartag_number1 = c(92, 57),
+      tbartag_number2 = c(10, 12)
+    )
+
+    expect_error(
+      check_data_format(
+        site = site,
+        outing = outing,
+        capture = capture,
+        recapture = recapture,
+        template = test_template_4,
+        complete = TRUE,
+        join = TRUE
+      ),
+      regexp = paste(
+        "All 'site_name' values in the outing table must be in the site table.",
+        "The following rows\\(s\\) in the outing table are causing the",
+        "issue\\: 2."
+      )
+    )
+  }
+)
 
 test_that("Error as template has 2 tables listed in join row", {
   site <- data.frame(
@@ -856,7 +985,8 @@ test_that("Error as template has 2 tables listed in join row", {
       capture = capture,
       recapture = recapture,
       template = test_template_4,
-      complete = TRUE
+      complete = TRUE,
+      join = TRUE
     ),
     regexp = paste(
       "Only 1 table can be listed per join row. Ensure the join row of the",
@@ -866,7 +996,6 @@ test_that("Error as template has 2 tables listed in join row", {
 })
 
 test_that("Passes when multiple joins occur", {
-
   visit <- data.frame(
     year = c(2010, 2010, 2010),
     month = c(7, 7, 7),
@@ -895,7 +1024,8 @@ test_that("Passes when multiple joins occur", {
     crew = crew,
     count = count,
     template = test_template_3,
-    complete = TRUE
+    complete = TRUE,
+    join = TRUE
   )
 
   expect_type(data, "list")
@@ -904,7 +1034,6 @@ test_that("Passes when multiple joins occur", {
 })
 
 test_that("Errors multiple joins on first join row", {
-
   visit <- data.frame(
     year = c(2010, 2010, 2010),
     month = c(7, 7, 7),
@@ -934,7 +1063,8 @@ test_that("Errors multiple joins on first join row", {
       crew = crew,
       count = count,
       template = test_template_3,
-      complete = TRUE
+      complete = TRUE,
+      join = TRUE
     ),
     regexp = paste(
       "All 'year', 'month', 'day', 'site' values in the count table must be",
@@ -945,7 +1075,6 @@ test_that("Errors multiple joins on first join row", {
 })
 
 test_that("Errors multiple joins on second join row", {
-
   visit <- data.frame(
     year = c(2010, 2010, 2010),
     month = c(7, 7, 7),
@@ -975,7 +1104,8 @@ test_that("Errors multiple joins on second join row", {
       crew = crew,
       count = count,
       template = test_template_3,
-      complete = TRUE
+      complete = TRUE,
+      join = TRUE
     ),
     regexp = paste(
       "All 'crew1' values in the count table must be in the crew table.",
@@ -987,63 +1117,66 @@ test_that("Errors multiple joins on second join row", {
 test_that(
   paste(
     "Errors when pkey in parent table is different then join by values listed"
-  ), {
-  site <- data.frame(
-    site_name = c("Pretty Bay", "Ugly Bay", "Green Bay")
-  )
-
-  outing <- data.frame(
-    outing_id = c(1L, 2L, 3L),
-    site_name = c("Pretty Bay", "Pretty Bay", "Pretty Bay"),
-    year = c(2010, 2010, 2010),
-    month = c(7, 7, 7),
-    day = c(15, 16, 17),
-    hour_start = c(9L, 11L, 8L),
-    minute_start = c(0, 0, 0),
-    guide = c("JT", "JT", "JT"),
-    rod_count = c(2, 3, 2),
-    comment = c(NA_character_, NA_character_, NA_character_)
-  )
-
-  capture <- data.frame(
-    outing_id = c(1L, 2L, 3L),
-    guide = c("JT", "JT", "JT"),
-    hour = c(7L, 8L, 7L),
-    minute = c(0L, 30L, 45L),
-    easting = c(1031941, 1031971, 1031944),
-    northing = c(892421, 892451, 892429),
-    species = c("BT", "CT", "CT"),
-    forklength_mm = c(100, 700, 300),
-    weight_kg = c(0.5, 10, 4),
-    tbartag_number1 = c(78, 91, 82),
-    tbartag_number2 = c(14, 18, 21),
-    released = c("yes", "no", "no")
-  )
-
-  recapture <- data.frame(
-    year = c(2009, 2009),
-    month = c(10, 10),
-    day = c(14, 15),
-    angler = c("Dave John", "John Smith"),
-    contact = c("250-637-9999", "250-557-1414"),
-    tbartag_number1 = c(92, 57),
-    tbartag_number2 = c(10, 12)
-  )
-
-  test_template_4$outing[4, 3] <- "TRUE"
-
-  expect_error(
-    data <- check_data_format(
-      site = site,
-      outing = outing,
-      capture = capture,
-      recapture = recapture,
-      template = test_template_4,
-      complete = TRUE
-    ),
-    regexp = paste(
-      "The pkey values in the parent table must match the columns listed in",
-      "the child table in the join row"
+  ),
+  {
+    site <- data.frame(
+      site_name = c("Pretty Bay", "Ugly Bay", "Green Bay")
     )
-  )
-})
+
+    outing <- data.frame(
+      outing_id = c(1L, 2L, 3L),
+      site_name = c("Pretty Bay", "Pretty Bay", "Pretty Bay"),
+      year = c(2010, 2010, 2010),
+      month = c(7, 7, 7),
+      day = c(15, 16, 17),
+      hour_start = c(9L, 11L, 8L),
+      minute_start = c(0, 0, 0),
+      guide = c("JT", "JT", "JT"),
+      rod_count = c(2, 3, 2),
+      comment = c(NA_character_, NA_character_, NA_character_)
+    )
+
+    capture <- data.frame(
+      outing_id = c(1L, 2L, 3L),
+      guide = c("JT", "JT", "JT"),
+      hour = c(7L, 8L, 7L),
+      minute = c(0L, 30L, 45L),
+      easting = c(1031941, 1031971, 1031944),
+      northing = c(892421, 892451, 892429),
+      species = c("BT", "CT", "CT"),
+      forklength_mm = c(100, 700, 300),
+      weight_kg = c(0.5, 10, 4),
+      tbartag_number1 = c(78, 91, 82),
+      tbartag_number2 = c(14, 18, 21),
+      released = c("yes", "no", "no")
+    )
+
+    recapture <- data.frame(
+      year = c(2009, 2009),
+      month = c(10, 10),
+      day = c(14, 15),
+      angler = c("Dave John", "John Smith"),
+      contact = c("250-637-9999", "250-557-1414"),
+      tbartag_number1 = c(92, 57),
+      tbartag_number2 = c(10, 12)
+    )
+
+    test_template_4$outing[4, 3] <- "TRUE"
+
+    expect_error(
+      data <- check_data_format(
+        site = site,
+        outing = outing,
+        capture = capture,
+        recapture = recapture,
+        template = test_template_4,
+        complete = TRUE,
+        join = TRUE
+      ),
+      regexp = paste(
+        "The pkey values in the parent table must match the columns listed in",
+        "the child table in the join row"
+      )
+    )
+  }
+)

--- a/tests/testthat/test-check-data-format.R
+++ b/tests/testthat/test-check-data-format.R
@@ -84,7 +84,7 @@ test_that(
         complete = "TRUE",
         join = TRUE
       ),
-      regexp = "`complete` must be a logical scalar \\(TRUE, FALSE or NA\\)."
+      regexp = "`complete` must be a flag \\(TRUE or FALSE\\)."
     )
   }
 )
@@ -146,7 +146,7 @@ test_that(
         complete = TRUE,
         join = "yes"
       ),
-      regexp = "`join` must be a logical scalar \\(TRUE, FALSE or NA\\)."
+      regexp = "`join` must be a flag \\(TRUE or FALSE\\)."
     )
   }
 )


### PR DESCRIPTION
Previous behaviour required that the complete set of data tables be provided to check joins. 
This was undesirable for the case where a subset of the data with a join is all that would be required for a function. 
i.e. all tables would be required as inputs to a function to test a single join between the two relevant tables.

This change allows joins to be checked independently of the complete check.